### PR TITLE
Fix thumbnail size not being applied to Project Window

### DIFF
--- a/Packages/dev.hai-vr.animation-viewer/Scripts/Editor/AnimationViewerEditorWindow.cs
+++ b/Packages/dev.hai-vr.animation-viewer/Scripts/Editor/AnimationViewerEditorWindow.cs
@@ -94,7 +94,7 @@ namespace Hai.AnimationViewer.Scripts.Editor
                     var listArea = _projectBrowserListAreaField.GetValue(editorWindow);
                     if (listArea != null)
                     {
-                        _listAreaGridSizeField.SetValue(listArea, thumbnailSize);
+                        _listAreaGridSizeField.SetValue(listArea, thumbnailSizeSerialized.intValue);
                         if (previousSize != thumbnailSizeSerialized.intValue)
                         {
                             EditorApplication.RepaintProjectWindow();


### PR DESCRIPTION
## Description

This PR fixes a bug where the animation thumbnail size slider in the Project Window was not working correctly.

## Problem

The thumbnail size feature was not applying the selected size to the Project Window. 
When adjusting the slider, the grid size remained unchanged.

## Root Cause

In the original implementation, the code was passing the `thumbnailSize` property object 
instead of its actual integer value (`thumbnailSizeSerialized.intValue`) to the 
`_listAreaGridSizeField.SetValue()` method.

## Solution

Changed line:
```csharp
_listAreaGridSizeField.SetValue(listArea, thumbnailSize);